### PR TITLE
CA-189168: Close tapdisk in deactivate, not detach

### DIFF
--- a/src/tapdisk/datapath.py
+++ b/src/tapdisk/datapath.py
@@ -40,10 +40,10 @@ class Implementation(xapi.storage.api.datapath.Datapath_skeleton):
             raise xapi.storage.api.volume.Volume_does_not_exist(u.path)
         return None
 
-    def deactivate(self, dbg, uri, domain):
+    def detach(self, dbg, uri, domain):
         return
 
-    def detach(self, dbg, uri, domain):
+    def deactivate(self, dbg, uri, domain):
         u = urlparse.urlparse(uri)
         # XXX need a datapath-specific error
         if not(os.path.exists(u.path)):


### PR DESCRIPTION
This ensures that, over a migrate, there's only one host with a tapdisk process
having a read/write filehandle open on the VHD.

This more closely mimics the SMAPIv2 behaviour and avoids data corruption.

Signed-off-by: Jonathan Davies <jonathan.davies@citrix.com>