### PR TITLE
Proper {at,de}tach / {ac,deac}tivate split

### DIFF
--- a/src/tapdisk/datapath.py
+++ b/src/tapdisk/datapath.py
@@ -8,14 +8,14 @@ import xapi.storage.api.datapath
 import xapi.storage.api.volume
 from xapi.storage.datapath import tapdisk, image
 from xapi.storage import log
+import pickle
 
+TD_PROC_METADATA_DIR = "/var/run/nonpersistent/dp-tapdisk"
+TD_PROC_METADATA_FILE = "meta.pickle"
 
 class Implementation(xapi.storage.api.datapath.Datapath_skeleton):
 
     def activate(self, dbg, uri, domain):
-        return
-
-    def attach(self, dbg, uri, domain):
         u = urlparse.urlparse(uri)
         # XXX need some datapath-specific errors below
         if not(os.path.exists(u.path)):
@@ -26,8 +26,13 @@ class Implementation(xapi.storage.api.datapath.Datapath_skeleton):
             img = image.Raw(u.path)
         else:
             raise
-        tap = tapdisk.create(dbg)
+        tap = self.load_tapdisk(dbg, uri)
         tap.open(dbg, img)
+        self.save_tapdisk(dbg, uri, tap)
+
+    def attach(self, dbg, uri, domain):
+        tap = tapdisk.create(dbg)
+        self.save_tapdisk(dbg, uri, tap)
         return {
             'domain_uuid': '0',
             'implementation': ['Tapdisk3', tap.block_device()],
@@ -41,16 +46,13 @@ class Implementation(xapi.storage.api.datapath.Datapath_skeleton):
         return None
 
     def detach(self, dbg, uri, domain):
-        return
+        tap = self.load_tapdisk(dbg, uri)
+        tap.destroy(dbg)
+        self.forget_tapdisk(dbg, uri)
 
     def deactivate(self, dbg, uri, domain):
-        u = urlparse.urlparse(uri)
-        # XXX need a datapath-specific error
-        if not(os.path.exists(u.path)):
-            raise xapi.storage.api.volume.Volume_does_not_exist(u.path)
-        tap = tapdisk.find_by_file(dbg, image.Path(u.path))
+        tap = self.load_tapdisk(dbg, uri)
         tap.close(dbg)
-        tap.destroy(dbg)
 
     def open(self, dbg, uri, persistent):
         u = urlparse.urlparse(uri)
@@ -58,6 +60,40 @@ class Implementation(xapi.storage.api.datapath.Datapath_skeleton):
         if not(os.path.exists(u.path)):
             raise xapi.storage.api.volume.Volume_does_not_exist(u.path)
         return None
+
+    def _metadata_dir(self, uri):
+        return TD_PROC_METADATA_DIR + "/" + uri
+
+    def save_tapdisk(self, dbg, uri, tap):
+        """ Record the tapdisk metadata for this URI in host-local storage """
+        dirname = self._metadata_dir(uri)
+        try:
+            os.makedirs(dirname, mode=0755)
+        except OSError as e:
+            if e.errno != 17: # 17 == EEXIST, which is harmless
+                raise e
+        with open(dirname + "/" + TD_PROC_METADATA_FILE, "w") as fd:
+            pickle.dump(tap.__dict__, fd)
+
+    def load_tapdisk(self, dbg, uri):
+        """ Recover the tapdisk metadata for this URI from host-local storage """
+        dirname = self._metadata_dir(uri)
+        if not(os.path.exists(dirname)):
+            # XXX throw a better exception
+            raise xapi.storage.api.volume.Volume_does_not_exist(dirname)
+        with open(dirname + "/" + TD_PROC_METADATA_FILE, "r") as fd:
+            meta = pickle.load(fd)
+            tap = tapdisk.Tapdisk(meta['minor'], meta['pid'], meta['f'])
+            tap.secondary = meta['secondary']
+            return tap
+
+    def forget_tapdisk(self, dbg, uri):
+        """ Delete the tapdisk metadata for this URI from host-local storage """
+        dirname = self._metadata_dir(uri)
+        try:
+            os.unlink(dirname + "/" + TD_PROC_METADATA_FILE)
+        except:
+            pass
 
 if __name__ == "__main__":
     log.log_call_argv()


### PR DESCRIPTION
Previously the mapping of SMAPI commands to tapdisk actions was:
 * attach => tap.create; tap.open
 * activate => noop
 * deactivate => tap.close; tap.destroy
 * detach => noop

Now the mapping of SMAPI commands to tapdisk actions is:
 * attach => tap.create
 * activate => tap.open
 * deactivate => tap.close
 * detach => tap.destroy

To achieve this, the plugin must remember the tapdisk created in attach so that
it can be referred to in activate, deactivate and detach. (Note that it is not
possible to rely on tapdisk.find_by_file as the filename is only associated with
the tapdisk instance after activate and before detach.) This is achieved by
pickling the Tapdisk object to non-persistent storage on the local host and
unpickling it when required.

Although it incurs filesystem I/O, it avoids the need to call
tapdisk.find_by_file -- which invokes tap-ctl list, which can sometimes be very
slow -- so is likely to improve performance, although this has not been
measured.

(Note that it is an explicit design decision for SMAPIv3 datapath plugins to
manage their own state to avoid making assumptions about other layers, so this
approach is preferable to relying on the caller to carry tapdisk metadata across
invocations of datapath plugin functions.)

Signed-off-by: Jonathan Davies <jonathan.davies@citrix.com>